### PR TITLE
🧪 [testing improvement] Add tests for add_common_responses in Swagger generator

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,4 +1,5 @@
 from xyra.swagger import (
+    add_common_responses,
     convert_path_to_openapi,
     extract_parameter_info,
     extract_path_parameters,
@@ -144,3 +145,26 @@ def test_swagger_endpoint():
     request = Request(mock_req, mock_res)
     request.is_json()
     mock_res.end.assert_called()
+
+
+def test_add_common_responses():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Test API", "version": "1.0.0"},
+        "paths": {},
+        "components": {
+            "responses": {},
+        },
+    }
+    updated_spec = add_common_responses(spec)
+
+    assert "400" in updated_spec["components"]["responses"]
+    assert "401" in updated_spec["components"]["responses"]
+    assert "404" in updated_spec["components"]["responses"]
+    assert "500" in updated_spec["components"]["responses"]
+
+    assert updated_spec["components"]["responses"]["400"]["description"] == "Bad Request"
+    assert (
+        updated_spec["components"]["responses"]["500"]["description"]
+        == "Internal Server Error"
+    )


### PR DESCRIPTION
🎯 **What:** The `add_common_responses` function in `xyra/swagger.py` was previously untested. This PR adds a comprehensive unit test for it.
📊 **Coverage:** The new test `test_add_common_responses` verifies that the function correctly augments a Swagger specification dictionary with standard HTTP response definitions (400, 401, 404, 500).
✨ **Result:** Increased test coverage for the Swagger generator, ensuring that common responses are correctly added to the OpenAPI specification.

---
*PR created automatically by Jules for task [4422408865657957584](https://jules.google.com/task/4422408865657957584) started by @RajaSunrise*