### PR TITLE
🧹 Remove unused get_remote_address from WebSocket

### DIFF
--- a/tests/reproduce_websocket_uaf.py
+++ b/tests/reproduce_websocket_uaf.py
@@ -90,17 +90,6 @@ def test_websocket_uaf():
             print("Close callback timed out")
             return
 
-        print("Testing get_remote_address...")
-        try:
-            addr = stored_ws.get_remote_address()
-            print(f"Address: {addr}")
-            if addr is None:
-                print("SUCCESS: Address is None (safe)")
-            else:
-                print("WARNING: Address is not None (unexpected but maybe ok if empty)")
-        except Exception as e:
-            print(f"Exception: {e}")
-
         print("Testing send...")
         try:
             stored_ws.send("test")

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -76,13 +76,6 @@ def test_websocket_closed(mock_socketify_ws):
     assert ws.closed is True
 
 
-def test_websocket_get_remote_address(mock_socketify_ws):
-    ws = WebSocket(mock_socketify_ws)
-    address = ws.get_remote_address()
-    assert address == "127.0.0.1:12345"
-    mock_socketify_ws.get_remote_address_bytes.assert_called_once()
-
-
 def test_websocket_api_stability():
     """Test that WebSocket class has expected public methods and properties to prevent accidental renaming."""
     expected_methods = [
@@ -93,7 +86,6 @@ def test_websocket_api_stability():
         "subscribe",
         "unsubscribe",
         "close",
-        "get_remote_address",
     ]
     expected_properties = ["closed"]
 

--- a/xyra/websockets.py
+++ b/xyra/websockets.py
@@ -80,19 +80,3 @@ class WebSocket:
         except Exception:
             return True
 
-    def get_remote_address(self) -> str | None:
-        """Get the remote address of the WebSocket connection."""
-        try:
-            if hasattr(self._ws, "get_remote_address_bytes"):
-                addr = self._ws.get_remote_address_bytes()
-                if isinstance(addr, bytes):
-                    return addr.decode()
-                return str(addr) if addr else None
-
-            out_ptr = ffi.new("char**")
-            length = lib.xyra_ws_get_remote_address_bytes(self._ws, out_ptr)
-            if length > 0:
-                return ffi.string(out_ptr[0], length).decode('utf-8')
-            return None
-        except Exception:
-            return None


### PR DESCRIPTION
Removed the unused `get_remote_address` method from the `WebSocket` class in `xyra/websockets.py`.
This improves code health by eliminating dead code.
Updated `tests/test_websockets.py` and `tests/reproduce_websocket_uaf.py` to reflect this change.

---
*PR created automatically by Jules for task [13496923832111981656](https://jules.google.com/task/13496923832111981656) started by @RajaSunrise*