### PR TITLE
🧹 Remove unused validate_swagger_spec function

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -5,7 +5,6 @@ from xyra.swagger import (
     extract_path_parameters,
     extract_tag_from_path,
     parse_docstring,
-    validate_swagger_spec,
 )
 
 
@@ -73,25 +72,6 @@ def test_extract_tag_from_path():
     assert extract_tag_from_path("/api/users") == "Api"
     assert extract_tag_from_path("/users/{id}") == "Users"
     assert extract_tag_from_path("/") == "Default"
-
-
-def test_validate_swagger_spec_valid():
-    spec = {
-        "openapi": "3.0.0",
-        "info": {"title": "Test API", "version": "1.0.0"},
-        "paths": {},
-    }
-    assert validate_swagger_spec(spec) is True
-
-
-def test_validate_swagger_spec_invalid():
-    # Missing required fields
-    spec = {"info": {"title": "Test"}}
-    assert validate_swagger_spec(spec) is False
-
-    # Missing info fields
-    spec = {"openapi": "3.0.0", "info": {}, "paths": {}}
-    assert validate_swagger_spec(spec) is False
 
 
 def test_generate_swagger_from_app():

--- a/xyra/swagger.py
+++ b/xyra/swagger.py
@@ -384,15 +384,3 @@ def add_common_responses(swagger_spec: dict[str, Any]) -> dict[str, Any]:
     return swagger_spec
 
 
-def validate_swagger_spec(spec: dict[str, Any]) -> bool:
-    """Basic validation of OpenAPI specification."""
-    required_fields = ["openapi", "info", "paths"]
-
-    for field in required_fields:
-        if field not in spec:
-            return False
-
-    if "title" not in spec["info"] or "version" not in spec["info"]:
-        return False
-
-    return True


### PR DESCRIPTION
🎯 **What:** Removed the `validate_swagger_spec` function from `xyra/swagger.py`, its import in `tests/test_swagger.py`, and the associated unit tests `test_validate_swagger_spec_valid` and `test_validate_swagger_spec_invalid`.
💡 **Why:** The function was identified as completely dead code. Removing it improves codebase maintainability and readability by reducing clutter without affecting any functionality.
✅ **Verification:** Verified the removal with `cat` and `grep` commands. Ran the swagger test suite (`uv run pytest tests/test_swagger.py`) which passed successfully, and ran linting via `uv run ruff check xyra/swagger.py tests/test_swagger.py` to ensure code style compliance.
✨ **Result:** A cleaner codebase with dead code and its unneeded tests removed.

---
*PR created automatically by Jules for task [9765003024669333365](https://jules.google.com/task/9765003024669333365) started by @RajaSunrise*