### PR TITLE
🧹 [Code Health] Remove unused `parse_json` method in Request

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -133,15 +133,6 @@ async def async_test_request_json_invalid():
         await request.json()
 
 
-def test_request_parse_json():
-    """Test synchronous JSON string parsing."""
-    req = Mock()
-    res = Mock()
-    request = Request(req, res)
-    data = request.parse_json('{"key": "value"}')
-    assert data == {"key": "value"}
-
-
 @pytest.mark.asyncio
 async def test_request_json_invalid():
     """Test invalid JSON."""
@@ -296,12 +287,3 @@ def test_request_query_params_fallback(mock_sys_modules):
     request = Request(req, res)
 
     assert request.query_params == {"key": ["value"]}
-
-
-def test_request_parse_json_bytes():
-    """Test synchronous JSON bytes parsing."""
-    req = Mock()
-    res = Mock()
-    request = Request(req, res)
-    data = request.parse_json(b'{"key": "value"}')
-    assert data == {"key": "value"}

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -58,18 +58,17 @@ def test_cors_wildcard_with_credentials_does_not_reflect_origin():
         assert name != "Access-Control-Allow-Credentials"
 
 
-def test_json_parsing_raises_exception():
-    """Test that Request.parse_json raises ValueError on invalid JSON."""
-    # We need a real Request object or mock enough of it
-    # But parse_json is a method on Request that uses orjson directly.
-    # We can just check the method behavior if we can instantiate Request.
-
+@pytest.mark.asyncio
+async def test_json_parsing_raises_exception():
+    """Test that Request.json() raises HTTPException on invalid JSON."""
     # Mocking socketify request/response
     req_mock = Mock()
     res_mock = Mock()
+    res_mock.get_data = pytest.importorskip("unittest.mock").AsyncMock(return_value=b"{invalid}")
 
     request = Request(req_mock, res_mock)
+    request.get_header = Mock(return_value="application/json")
 
     from xyra.exceptions import HTTPException
     with pytest.raises(HTTPException, match="Invalid JSON"):
-        request.parse_json("{invalid}")
+        await request.json()

--- a/xyra/request.py
+++ b/xyra/request.py
@@ -476,29 +476,12 @@ class Request:
             return {}
 
         parsed = None
-        if isinstance(body, bytes):
-            parsed = self.parse_json(body)
-        elif isinstance(body, str):
-            parsed = self.parse_json(body)
-        else:
-            # Fallback for other types
-            parsed = self.parse_json(str(body))
-
-        # Cache parsed JSON
-        self._json_cache = parsed
-        return parsed
-
-    def parse_json(self, json_string: str | bytes) -> Any:
-        """
-        Parse a JSON string or bytes synchronously.
-
-        usage:
-            json_str = '{"name": "John"}'
-            data = req.parse_json(json_str)
-            print(data["name"])  # "John"
-        """
         try:
-            return json_lib.loads(json_string)
+            if isinstance(body, (bytes, str)):
+                parsed = json_lib.loads(body)
+            else:
+                # Fallback for other types
+                parsed = json_lib.loads(str(body))
         except Exception as e:
             from .exceptions import bad_request
             logger = get_logger("xyra")
@@ -506,6 +489,10 @@ class Request:
             # SECURITY: Raise HTTP 400 Bad Request instead of ValueError to prevent 500 error logs DoS
             # SECURITY: Do not leak exception details to the client
             raise bad_request("Invalid JSON format") from None
+
+        # Cache parsed JSON
+        self._json_cache = parsed
+        return parsed
 
     async def form(self) -> dict[str, str]:
         """


### PR DESCRIPTION
- 🎯 **What:** Removed the unused `parse_json` method from `Request` and inlined its logic into `json`.
- 💡 **Why:** Reduces technical debt and improves maintainability by removing unused code.
- ✅ **Verification:** Passed all tests and ran the full test suite.
- ✨ **Result:** Cleaner codebase with no functional changes.

---
*PR created automatically by Jules for task [12614937680066414484](https://jules.google.com/task/12614937680066414484) started by @RajaSunrise*