### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in static file serving

### DIFF
--- a/xyra/application.py
+++ b/xyra/application.py
@@ -368,7 +368,7 @@ class App:
                 )
 
                 # Verify the resolved path is within the static directory
-                if not abs_path.startswith(abs_directory):
+                if not os.path.commonpath([abs_directory, abs_path]) == os.path.normpath(abs_directory):
                     res.status(403).text("Forbidden")
                     return
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal bypass via directory substring match in `startswith()` checks. For instance, if serving `/tmp/test/` and an attacker accesses `/tmp/test_hacked/hello.txt`, `startswith()` considers it valid, allowing bypassing sandbox confinement.
🎯 Impact: Attackers can potentially access files in sibling directories with similar prefixes, leading to unauthorized access.
🔧 Fix: Used `os.path.commonpath` to definitively verify the resolved path falls within the allowed base directory.
✅ Verification: Ran `uv run pytest tests/test_security_path_traversal.py tests/test_static_path_traversal_windows.py tests/test_staticfiles_security.py` and ensured tests pass.

---
*PR created automatically by Jules for task [8817489371768210693](https://jules.google.com/task/8817489371768210693) started by @RajaSunrise*