### PR TITLE
🧪 Add missing error path test for format_cookie CFFI string decode fallback

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -52,6 +52,7 @@ def test_response_send_string(mock_socketify_response):
         mock_socketify_response.end.assert_called_once_with("Hello World")
     assert response._ended is True
 
+
 def test_response_send_bytes(mock_socketify_response):
     response = Response(mock_socketify_response)
     response.send(b"Hello World")
@@ -319,8 +320,9 @@ def test_response_set_cookie_same_site_none_secure(mock_socketify_response):
     assert "SameSite=none" in cookie
     assert "Secure" in cookie
 
-@patch('xyra.response.ffi')
-@patch('xyra.response.lib')
+
+@patch("xyra.response.ffi")
+@patch("xyra.response.lib")
 def test_format_cookie_cffi_fallback(mock_lib, mock_ffi):
     # Testing the fallback path in xyra.response.format_cookie when buffer slice throws
     from xyra.response import format_cookie

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -318,3 +318,33 @@ def test_response_set_cookie_same_site_none_secure(mock_socketify_response):
     cookie = response.headers["Set-Cookie"]
     assert "SameSite=none" in cookie
     assert "Secure" in cookie
+
+@patch('xyra.response.ffi')
+@patch('xyra.response.lib')
+def test_format_cookie_cffi_fallback(mock_lib, mock_ffi):
+    # Testing the fallback path in xyra.response.format_cookie when buffer slice throws
+    from xyra.response import format_cookie
+
+    class BrokenCffiBuf:
+        def __getitem__(self, key):
+            raise Exception("Simulated bytes cast error")
+
+    broken_buf = BrokenCffiBuf()
+
+    # We must explicitly delete the side_effect on mock_ffi.string
+    # to bypass the first mock-specific block
+    del mock_ffi.string.side_effect
+
+    def ffi_new_mock(type_str, size=None):
+        if "char[]" in type_str:
+            return broken_buf
+        return [10]
+
+    mock_ffi.new.side_effect = ffi_new_mock
+    mock_ffi.string.return_value = b"mocked=fallback_value"
+    mock_ffi.NULL = None
+
+    res = format_cookie("mocked", "value")
+
+    assert res == "mocked=fallback_value"
+    mock_ffi.string.assert_called_once_with(broken_buf, 10)


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing unit test coverage for the exception fallback path when CFFI string decoding fails in `xyra/response.py`'s `format_cookie` method.
📊 **Coverage:** A new test case `test_format_cookie_cffi_fallback` was added to `tests/test_response.py`. This test mocks the `ffi` and `lib` dependencies and introduces a custom `BrokenCffiBuf` object that purposefully throws an `Exception` on buffer slicing. This triggers the exception block, explicitly validating that the fallback `ffi.string(out_buf, val_int).decode('utf-8')` is executed correctly.
✨ **Result:** Test coverage for `xyra/response.py`'s edge case CFFI handling is significantly improved, ensuring the fallback mechanism behaves securely and correctly under error conditions.

---
*PR created automatically by Jules for task [18265037551433574151](https://jules.google.com/task/18265037551433574151) started by @RajaSunrise*