### PR TITLE
🧪 Add missing tests for WebSocket origin parsing

### DIFF
--- a/tests/test_websocket_cswsh.py
+++ b/tests/test_websocket_cswsh.py
@@ -54,3 +54,12 @@ def test_websocket_default_upgrade_handler():
     # 4. Origin present but no Host -> Deny
     req = create_request({"Origin": "https://example.com"})
     assert upgrade_handler(req) is False
+
+    # 5. Malformed Origin -> Deny (Coverage for exception path)
+    # Using 'http://]' which causes ValueError: Invalid IPv6 URL in urlparse
+    req = create_request({"Host": "example.com", "Origin": "http://]"})
+    assert upgrade_handler(req) is False
+
+    # 6. Origin has port but Host does not -> Allow (Coverage for line 264)
+    req = create_request({"Host": "localhost", "Origin": "http://localhost:8000"})
+    assert upgrade_handler(req) is True


### PR DESCRIPTION
🎯 **What:** Added tests for missing error path during WebSocket origin parsing in application.py.
📊 **Coverage:** Covered the exception block for malformed Origin headers (`urlparse` ValueError) and covered the case where Origin has a port but the Host does not.
✨ **Result:** Improved test coverage for WebSocket upgrade security handlers.

---
*PR created automatically by Jules for task [11219194655885452778](https://jules.google.com/task/11219194655885452778) started by @RajaSunrise*