### PR TITLE
🧹 [code health] Refactor importlib.util import in __main__.py

### DIFF
--- a/benchmark/app_fastapi.py
+++ b/benchmark/app_fastapi.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from fastapi.responses import PlainTextResponse, HTMLResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse
 
 app = FastAPI()
 

--- a/benchmark/run_benchmarks.py
+++ b/benchmark/run_benchmarks.py
@@ -1,9 +1,9 @@
 import os
 import re
+import shlex
+import signal
 import subprocess
 import time
-import signal
-import shlex
 
 
 def kill_process_on_port(port):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,12 +1,10 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 # from socketify import OpCode
 from xyra.websockets import WebSocket
 
-
-from unittest.mock import patch
 
 @pytest.fixture
 def mock_fallback_ws():

--- a/xyra/__main__.py
+++ b/xyra/__main__.py
@@ -1,7 +1,7 @@
 import argparse
-import importlib.util
 import os
 import sys
+from importlib.util import module_from_spec, spec_from_file_location
 
 
 def load_app_from_file(file_path: str):
@@ -29,14 +29,14 @@ def load_app_from_file(file_path: str):
         module_name = os.path.splitext(os.path.basename(file_path))[0]
 
         # Create module spec for dynamic loading
-        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        spec = spec_from_file_location(module_name, file_path)
 
         if spec is None or spec.loader is None:
             print(f"Error: Could not load module from '{file_path}'")
             sys.exit(1)
 
         # Create and execute the module
-        module = importlib.util.module_from_spec(spec)
+        module = module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)
 


### PR DESCRIPTION
- **What:** Refactored `import importlib.util` to directly import the used functions.
- **Why:** Resolves unused import issues and improves readability.
- **Verification:** Ran linters and syntax checks.
- **Result:** Cleaner code and no unused import warnings.

---
*PR created automatically by Jules for task [12413060451783593871](https://jules.google.com/task/12413060451783593871) started by @RajaSunrise*