### PR TITLE
Fix Ruff B004 warning by using callable()

### DIFF
--- a/xyra/application.py
+++ b/xyra/application.py
@@ -499,7 +499,6 @@ class App:
         middleware_chain = []
         for middleware in middlewares:
             handler_to_inspect = middleware
-            # FIX RUFF B004: Use callable() instead of hasattr(..., "__call__")
             if not inspect.isfunction(middleware) and callable(middleware):
                 handler_to_inspect = middleware.__call__
 


### PR DESCRIPTION
Removed the TODO comment referencing Ruff B004 since the code already uses callable() instead of hasattr.

---
*PR created automatically by Jules for task [17964842719310441686](https://jules.google.com/task/17964842719310441686) started by @RajaSunrise*