### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSTI vulnerability in template rendering

### DIFF
--- a/xyra/templating.py
+++ b/xyra/templating.py
@@ -2,7 +2,8 @@ from collections.abc import Callable
 from typing import Any
 
 try:
-    from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+    from jinja2 import FileSystemLoader, TemplateNotFound
+    from jinja2.sandbox import SandboxedEnvironment as Environment
 except ImportError:
     class Environment:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Template Injection (SSTI). The application was using the standard Jinja2 `Environment` which allows templates to access sensitive Python attributes (e.g., `__class__`, `__subclasses__`) if a template rendering vulnerability exists.
🎯 **Impact:** If an attacker can control template input, they could exploit this to achieve remote code execution (RCE) on the server, potentially gaining full control over the application environment.
🔧 **Fix:** Replaced the standard Jinja2 `Environment` with `SandboxedEnvironment` (aliased as `Environment`) in `xyra/templating.py`. This sandboxes template execution, restricting access to sensitive attributes and significantly reducing the risk of SSTI-driven arbitrary code execution.
✅ **Verification:** Verified by attempting to access `__class__` and `__mro__` in a template string, which now correctly throws a `SecurityError` instead of succeeding. Existing template tests via `uv run pytest tests/test_templating.py` continue to pass without regression.

---
*PR created automatically by Jules for task [1664941739490284091](https://jules.google.com/task/1664941739490284091) started by @RajaSunrise*