### PR TITLE
Fix TypeError when sending JSON response on PyPy/CFFI

### DIFF
--- a/xyra/response.py
+++ b/xyra/response.py
@@ -314,6 +314,8 @@ class Response:
         """
         # PERF: json_lib (orjson) returns bytes, send them directly to avoid decode/encode overhead
         json_data = json_lib.dumps(data)
+        if isinstance(json_data, str):
+            json_data = json_data.encode('utf-8')
 
         if self._ended:
             return


### PR DESCRIPTION
The `json_lib.dumps` function can return a string (especially when using the standard `json` or `ujson` libraries on PyPy). Passing a unicode object (string) to `ffi.from_buffer` causes a `TypeError` on PyPy's CFFI implementation. This PR explicitly encodes the JSON output to UTF-8 bytes if it's a string, ensuring compatibility with CFFI while maintaining the performance optimization for libraries like `orjson` that already return bytes.

---
*PR created automatically by Jules for task [2207388787539204440](https://jules.google.com/task/2207388787539204440) started by @RajaSunrise*