### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via MIME sniffing in Response.send()

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -46,19 +46,13 @@ def test_response_header(mock_socketify_response):
 def test_response_send_string(mock_socketify_response):
     response = Response(mock_socketify_response)
     response.send("Hello World")
-    if hasattr(mock_socketify_response, "end_fast"):
-        mock_socketify_response.end_fast.assert_called_once_with("Hello World")
-    else:
-        mock_socketify_response.end.assert_called_once_with("Hello World")
+    mock_socketify_response.end.assert_called_once_with("Hello World")
     assert response._ended is True
 
 def test_response_send_bytes(mock_socketify_response):
     response = Response(mock_socketify_response)
     response.send(b"Hello World")
-    if hasattr(mock_socketify_response, "end_fast"):
-        mock_socketify_response.end_fast.assert_called_once_with(b"Hello World")
-    else:
-        mock_socketify_response.end.assert_called_once_with(b"Hello World")
+    mock_socketify_response.end.assert_called_once_with(b"Hello World")
     assert response._ended is True
 
 

--- a/tests/test_sentinel_fixes.py
+++ b/tests/test_sentinel_fixes.py
@@ -137,13 +137,10 @@ async def test_header_truncation_mitigation():
 
     await final_handler(mock_native_res_normal, mock_native_req_normal)
 
-    if hasattr(mock_native_res_normal, "end_fast"):
-        mock_native_res_normal.end_fast.assert_called_with("OK")
-    else:
-        try:
-            mock_native_res_normal.end.assert_called_with("OK")
-        except AssertionError:
-            pass # fallback handles it
+    try:
+        mock_native_res_normal.end.assert_called_with("OK")
+    except AssertionError:
+        pass # fallback handles it
 
     # 2. Test excessive headers (over limit)
     mock_native_req_huge = Mock()

--- a/xyra/response.py
+++ b/xyra/response.py
@@ -249,30 +249,6 @@ class Response:
         if self._ended:
             return
 
-        # PERF: Fast path for simple 200 OK responses
-        if self.status_code == 200 and not self._headers_dict:
-            if hasattr(self._res, "end_fast"):
-                self._res.end_fast(data)
-                self._ended = True
-                return
-            elif lib and hasattr(lib, "xyra_res_end_fast"):
-                if isinstance(data, str):
-                    c_data = data.encode('utf-8')
-                else:
-                    c_data = data
-                self._temp_data_cache = c_data
-                buf = ffi.from_buffer("char[]", self._temp_data_cache)
-                lib.xyra_res_end_fast(self._res, buf, len(self._temp_data_cache))
-                self._ended = True
-                return
-
-        # Write status code
-        status_str = str(self.status_code)
-        if hasattr(self._res, "write_status"):
-            self._res.write_status(status_str)
-        else:
-            lib.xyra_res_write_status(self._res, status_str.encode('utf-8'), len(status_str.encode('utf-8')))
-
         # SECURITY: Set default Content-Type if missing to prevent MIME sniffing/XSS.
         # Browsers may sniff "text/html" from response body if Content-Type is missing.
         # Default to safe types: text/plain for strings, application/octet-stream for bytes.
@@ -281,6 +257,13 @@ class Response:
                 self._header_fast("Content-Type", "text/plain; charset=utf-8")
             else:
                 self._header_fast("Content-Type", "application/octet-stream")
+
+        # Write status code
+        status_str = str(self.status_code)
+        if hasattr(self._res, "write_status"):
+            self._res.write_status(status_str)
+        else:
+            lib.xyra_res_write_status(self._res, status_str.encode('utf-8'), len(status_str.encode('utf-8')))
 
         # Write headers
         self._write_headers()


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `Response.send()` method used a "fast path" (`end_fast`) for HTTP 200 responses with an empty header dictionary. Because it completely bypassed writing the headers, no `Content-Type` was ever set for these responses. If user-controlled string payloads were sent without an explicit `Content-Type`, browsers could MIME-sniff the response as `text/html` and execute malicious scripts, resulting in Cross-Site Scripting (XSS).
🎯 **Impact:** If an attacker can inject malicious HTML/JS payloads via input that is reflected in the response (e.g. `res.send(user_input)`), the browser will execute it, allowing session hijacking, arbitrary script execution, and other XSS-related attacks.
🔧 **Fix:** I moved the logic that secures the response by setting a default `Content-Type` (to `text/plain; charset=utf-8` for strings and `application/octet-stream` for bytes) to before the header serialization. Because the headers dictionary is no longer empty when this default is applied, the fast path is naturally bypassed, preventing MIME-sniffing. I then removed the unused dead code for the fast path entirely to avoid confusion.
✅ **Verification:** Verified by creating an XSS reproduction script (`tests/repro_xss_send.py`), checking that the response has a correct `Content-Type`, and updating the `test_response_send_string` and `test_response_send_bytes` unit tests to account for `end_fast` removal. All relevant tests pass.

---
*PR created automatically by Jules for task [7545968173904882644](https://jules.google.com/task/7545968173904882644) started by @RajaSunrise*