### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent HTTP Header Truncation Bypass

### DIFF
--- a/xyra/application.py
+++ b/xyra/application.py
@@ -643,6 +643,11 @@ class App:
                         _sync_req._scheme_cache = None
                         _sync_req._remote_addr_cache = None
 
+                        # SECURITY: Check for header truncation to prevent security bypasses
+                        if getattr(_sync_req._req, "headers_truncated", False):
+                            _sync_res.status(431).send("Request Header Fields Too Large")
+                            return
+
                         h_func(_sync_req, _sync_res)
 
                         # Fast end for empty text responses and json


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Prevent HTTP Header Truncation Bypass

🚨 Severity: CRITICAL
💡 Vulnerability: When optimizing HTTP handlers in `xyra/application.py` (`create_fastest_sync_handler`), the security validation checking for `headers_truncated` was intentionally missing/skipped.
🎯 Impact: Attackers could send an oversized request with >100 headers, forcing silent truncation of the incoming HTTP headers. By pushing legitimate security headers like `X-Forwarded-For` or `Authorization` out of the parsing buffer, they could bypass IP spoofing protections, rate limiting, and access controls.
🔧 Fix: Added explicit enforcement of the `headers_truncated` validation in `fastest_sync_handler` within `create_fastest_sync_handler`. If headers are truncated, the server immediately rejects the request with a `431 Request Header Fields Too Large` response.
✅ Verification: Ran test suite via `uv run pytest tests/test_application.py` (8/8 passed). Tested that a large number of headers properly triggers the 431 response rather than silently processing the request.

---
*PR created automatically by Jules for task [14975168320938271678](https://jules.google.com/task/14975168320938271678) started by @RajaSunrise*