### PR TITLE
Fix Bandit B110 warning in xyra/application.py

### DIFF
--- a/xyra/application.py
+++ b/xyra/application.py
@@ -583,7 +583,7 @@ class App:
                         res.write_status("500")
                         res.end('{"error": "Internal Server Error"}')
                 except Exception:
-                    # FIX BANDIT B110: Avoid silent pass. Log the failure to debug.
+                    # Log the failure to debug
                     req_logger.debug(
                         "Failed to send 500 Internal Server Error response",
                         exc_info=True,


### PR DESCRIPTION
Clean up the Bandit B110 issue tag comment in exception handler in xyra/application.py while preserving exception logging functionality.

---
*PR created automatically by Jules for task [4997143077284959199](https://jules.google.com/task/4997143077284959199) started by @RajaSunrise*