### PR TITLE
Clean up stale comment in test_security_dos.py

### DIFF
--- a/tests/test_security_dos.py
+++ b/tests/test_security_dos.py
@@ -50,7 +50,6 @@ async def test_get_data_body_size_limit():
     await asyncio.sleep(0)
 
     # Verify that the connection was closed immediately to prevent DoS
-    # This checks that the fix for "Large Body Attacks" is working correctly
     if hasattr(mock_res, "close"):
         mock_res.close.assert_called()
 


### PR DESCRIPTION
Removed a redundant/stale comment in `tests/test_security_dos.py` that was triggering issue scanners as a TODO/fix item while keeping the underlying test assertions intact.

---
*PR created automatically by Jules for task [14557023082031720289](https://jules.google.com/task/14557023082031720289) started by @RajaSunrise*